### PR TITLE
fix(settings): wire core Return Link toggle to handler (linkOptions)

### DIFF
--- a/bot/modules/settings.py
+++ b/bot/modules/settings.py
@@ -445,7 +445,7 @@ async def toggle_extract_cover_cb(client, cb:CallbackQuery):
         except:
             pass
 
-@Client.on_callback_query(filters.regex(pattern=r"^linkOption"))
+@Client.on_callback_query(filters.regex(pattern=r"^linkOptions$"))
 async def link_option_cb(client, cb:CallbackQuery):
     if await check_user(cb.from_user.id, restricted=True):
         options = ['False', 'Index', 'RCLONE', 'Both']


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of the “Link Options” action in Settings by ensuring only the intended selection triggers its response, preventing unintended matches and accidental activations.
* **Stability**
  * Reduced unexpected behavior during settings interactions related to link options, leading to more predictable navigation and responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->