### PR TITLE
feat(settings): add preset buttons guard toggles for Apple and Tidal …

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ This new system replaces the old, non-functional UI buttons and gives you comple
 - **FFmpeg Path**: The bot will always forcefully set the `path_binary_ffmpeg` to `/usr/bin/ffmpeg` before every download to ensure video processing and FLAC extraction works reliably. You do not need to set this key yourself.
 - **Download Path**: The bot will always set the `download_base_path` to a temporary, per-task directory to ensure downloads do not conflict. The `TIDAL_NG_DOWNLOAD_PATH` environment variable can still be used to override this.
     - New: You can now override the Tidal NG `download_base_path` via environment: `TIDAL_NG_DOWNLOAD_BASE_PATH`. This takes precedence over `settings.json` (legacy `TIDAL_NG_DOWNLOAD_PATH` also supported).
+    - New: A top-of-panel toggle, “Preset Buttons: ON/OFF”, lets you temporarily hide the cycling/toggle preset buttons to avoid accidental changes. Interactive JSON commands (`/tidal_ng_*`) remain available.
 
 ## Apple Wrapper Controls (Apple Music)
 
@@ -213,6 +214,19 @@ The Apple provider now has its own zip controls and a rich settings panel driven
   - Naming: album folder format presets, playlist folder format presets, song file format presets
 
 Commands `/config_get`, `/config_set`, `/config_toggle`, `/config_show` still work and write to `config.yaml` safely with backups.
+
+### Flags Popup for Apple /download
+
+- Enable in Settings → Providers → Apple Music → “Flags Popup”.
+- When ON, sending `/download <apple_url>` opens a quick picker to avoid typing flags:
+  - Single track: applies `--song`
+  - Atmos album: applies `--atmos`
+  - Atmos track: applies `--song --atmos`
+- The popup closes after selection or cancel. When OFF, manual flags still work (e.g., `/download --song <url>`).
+
+### Guard against accidental touches
+
+- A top-of-panel toggle, “Preset Buttons: ON/OFF”, hides the cycling/toggle preset buttons in the Apple panel to prevent accidental config edits. The interactive editor remains available.
 
 ## Commands and Usage
 

--- a/bot/modules/provider_settings.py
+++ b/bot/modules/provider_settings.py
@@ -155,9 +155,18 @@ async def apple_cb(c, cb: CallbackQuery):
         buttons = []
         # Interactive editing entry
         buttons.append([InlineKeyboardButton("✏️ Interactive Edit (Apple)", callback_data="appleInteractive")])
-        for fmt, label in formats.items():
-            buttons.append([InlineKeyboardButton(label, callback_data=f"appleF_{fmt}")])
-        buttons.append([InlineKeyboardButton("Quality Settings", callback_data="appleQ")])
+        # Top-level guard toggle for cycling presets
+        try:
+            from ..settings import bot_set as _bs_guard
+            guard_label = f"Preset Buttons: {'ON ✅' if getattr(_bs_guard, 'apple_cycle_presets_enabled', True) else 'OFF'}"
+        except Exception:
+            guard_label = "Preset Buttons: ON ✅"
+        buttons.append([InlineKeyboardButton(guard_label, callback_data="appleTogglePresetGuard")])
+        from ..settings import bot_set as _bs_guard2
+        if getattr(_bs_guard2, 'apple_cycle_presets_enabled', True):
+            for fmt, label in formats.items():
+                buttons.append([InlineKeyboardButton(label, callback_data=f"appleF_{fmt}")])
+            buttons.append([InlineKeyboardButton("Quality Settings", callback_data="appleQ")])
         buttons.append([
             InlineKeyboardButton("🧩 Setup Wrapper", callback_data="appleSetup"),
             InlineKeyboardButton("⏹️ Stop Wrapper", callback_data="appleStop")
@@ -167,58 +176,67 @@ async def apple_cb(c, cb: CallbackQuery):
             InlineKeyboardButton(zip_playlist_label, callback_data="appleToggleZipPlaylist")
         ])
         # Artwork & cover controls
-        buttons.append([
-            InlineKeyboardButton(lab_cover_size, callback_data="appleCycleCoverSize"),
-            InlineKeyboardButton(lab_cover_fmt, callback_data="appleCycleCoverFormat"),
-        ])
-        buttons.append([
-            InlineKeyboardButton(lab_embed_cover, callback_data="appleToggleEmbedCover"),
-            InlineKeyboardButton(lab_save_artist, callback_data="appleToggleSaveArtistCover"),
-        ])
+        if getattr(_bs_guard2, 'apple_cycle_presets_enabled', True):
+            buttons.append([
+                InlineKeyboardButton(lab_cover_size, callback_data="appleCycleCoverSize"),
+                InlineKeyboardButton(lab_cover_fmt, callback_data="appleCycleCoverFormat"),
+            ])
+        if getattr(_bs_guard2, 'apple_cycle_presets_enabled', True):
+            buttons.append([
+                InlineKeyboardButton(lab_embed_cover, callback_data="appleToggleEmbedCover"),
+                InlineKeyboardButton(lab_save_artist, callback_data="appleToggleSaveArtistCover"),
+            ])
         # Lyrics controls
-        buttons.append([
-            InlineKeyboardButton(lab_lrc_type, callback_data="appleCycleLyricsType"),
-            InlineKeyboardButton(lab_lrc_fmt, callback_data="appleCycleLyricsFormat"),
-        ])
-        buttons.append([
-            InlineKeyboardButton(lab_embed_lrc, callback_data="appleToggleEmbedLrc"),
-            InlineKeyboardButton(lab_save_lrc, callback_data="appleToggleSaveLrc"),
-        ])
+        if getattr(_bs_guard2, 'apple_cycle_presets_enabled', True):
+            buttons.append([
+                InlineKeyboardButton(lab_lrc_type, callback_data="appleCycleLyricsType"),
+                InlineKeyboardButton(lab_lrc_fmt, callback_data="appleCycleLyricsFormat"),
+            ])
+            buttons.append([
+                InlineKeyboardButton(lab_embed_lrc, callback_data="appleToggleEmbedLrc"),
+                InlineKeyboardButton(lab_save_lrc, callback_data="appleToggleSaveLrc"),
+            ])
         # Animated artwork / MV
-        buttons.append([
-            InlineKeyboardButton(lab_anim_aw, callback_data="appleToggleAnimatedArtwork"),
-            InlineKeyboardButton(lab_emby_anim, callback_data="appleToggleEmbyAnimatedArtwork"),
-        ])
-        buttons.append([
-            InlineKeyboardButton(lab_mv_audio, callback_data="appleCycleMvAudioType"),
-            InlineKeyboardButton(lab_mv_max, callback_data="appleCycleMvMax"),
-        ])
+        if getattr(_bs_guard2, 'apple_cycle_presets_enabled', True):
+            buttons.append([
+                InlineKeyboardButton(lab_anim_aw, callback_data="appleToggleAnimatedArtwork"),
+                InlineKeyboardButton(lab_emby_anim, callback_data="appleToggleEmbyAnimatedArtwork"),
+            ])
+        if getattr(_bs_guard2, 'apple_cycle_presets_enabled', True):
+            buttons.append([
+                InlineKeyboardButton(lab_mv_audio, callback_data="appleCycleMvAudioType"),
+                InlineKeyboardButton(lab_mv_max, callback_data="appleCycleMvMax"),
+            ])
         # Playlist enhancements
-        buttons.append([
-            InlineKeyboardButton(lab_dl_cov_pl, callback_data="appleToggleDlAlbumCoverPlaylist"),
-            InlineKeyboardButton(lab_use_songinfo, callback_data="appleToggleUseSonginfoPlaylist"),
-        ])
+        if getattr(_bs_guard2, 'apple_cycle_presets_enabled', True):
+            buttons.append([
+                InlineKeyboardButton(lab_dl_cov_pl, callback_data="appleToggleDlAlbumCoverPlaylist"),
+                InlineKeyboardButton(lab_use_songinfo, callback_data="appleToggleUseSonginfoPlaylist"),
+            ])
         # Concurrency and naming presets
-        buttons.append([
-            InlineKeyboardButton(lab_limit_max, callback_data="appleCycleLimitMax"),
-            InlineKeyboardButton("Workers Info", callback_data="noop"),
-        ])
-        buttons.append([
-            InlineKeyboardButton(lab_album_fmt, callback_data="appleCycleAlbumFolderFormat"),
-            InlineKeyboardButton(lab_playlist_fmt, callback_data="appleCyclePlaylistFolderFormat"),
-        ])
-        buttons.append([
-            InlineKeyboardButton(lab_song_fmt, callback_data="appleCycleSongFileFormat"),
-        ])
+        if getattr(_bs_guard2, 'apple_cycle_presets_enabled', True):
+            buttons.append([
+                InlineKeyboardButton(lab_limit_max, callback_data="appleCycleLimitMax"),
+                InlineKeyboardButton("Workers Info", callback_data="noop"),
+            ])
+        if getattr(_bs_guard2, 'apple_cycle_presets_enabled', True):
+            buttons.append([
+                InlineKeyboardButton(lab_album_fmt, callback_data="appleCycleAlbumFolderFormat"),
+                InlineKeyboardButton(lab_playlist_fmt, callback_data="appleCyclePlaylistFolderFormat"),
+            ])
+            buttons.append([
+                InlineKeyboardButton(lab_song_fmt, callback_data="appleCycleSongFileFormat"),
+            ])
         # Audio pipeline and network options
-        buttons.append([
-            InlineKeyboardButton(lab_aac_type, callback_data="appleCycleAacType"),
-            InlineKeyboardButton(lab_alac_max, callback_data="appleCycleAlacMax"),
-        ])
-        buttons.append([
-            InlineKeyboardButton(lab_atmos_max, callback_data="appleCycleAtmosMax"),
-            InlineKeyboardButton(lab_m3u8_mode, callback_data="appleCycleM3u8Mode"),
-        ])
+        if getattr(_bs_guard2, 'apple_cycle_presets_enabled', True):
+            buttons.append([
+                InlineKeyboardButton(lab_aac_type, callback_data="appleCycleAacType"),
+                InlineKeyboardButton(lab_alac_max, callback_data="appleCycleAlacMax"),
+            ])
+            buttons.append([
+                InlineKeyboardButton(lab_atmos_max, callback_data="appleCycleAtmosMax"),
+                InlineKeyboardButton(lab_m3u8_mode, callback_data="appleCycleM3u8Mode"),
+            ])
         # Apple flags popup toggle
         try:
             from ..settings import bot_set as _bs2
@@ -421,6 +439,19 @@ async def apple_toggle_flags_popup(c: Client, cb: CallbackQuery):
             from ..helpers.database.pg_impl import set_db
             bot_set.apple_flags_popup = not bool(getattr(bot_set, 'apple_flags_popup', False))
             set_db.set_variable('APPLE_FLAGS_POPUP', bot_set.apple_flags_popup)
+        except Exception:
+            pass
+        await apple_cb(c, cb)
+
+
+@Client.on_callback_query(filters.regex(pattern=r"^appleTogglePresetGuard$"))
+async def apple_toggle_preset_guard(c: Client, cb: CallbackQuery):
+    if await check_user(cb.from_user.id, restricted=True):
+        try:
+            from ..settings import bot_set
+            from ..helpers.database.pg_impl import set_db
+            bot_set.apple_cycle_presets_enabled = not bool(getattr(bot_set, 'apple_cycle_presets_enabled', True))
+            set_db.set_variable('APPLE_CYCLE_PRESETS_ENABLED', bot_set.apple_cycle_presets_enabled)
         except Exception:
             pass
         await apple_cb(c, cb)
@@ -1079,8 +1110,18 @@ async def tidal_ng_cb(c, cb: CallbackQuery):
         mcd = int(_cfg.get('metadata_cover_dimension', 320) or 320)
         mcd_label = f"Cover Size: {mcd}"
 
+        # Top-level guard toggle for Tidal NG preset cycling
+        try:
+            from ..settings import bot_set as _bs_guard
+            guard_label = f"Preset Buttons: {'ON ✅' if getattr(_bs_guard, 'tidal_ng_cycle_presets_enabled', True) else 'OFF'}"
+            guard_enabled = getattr(_bs_guard, 'tidal_ng_cycle_presets_enabled', True)
+        except Exception:
+            guard_label = "Preset Buttons: ON ✅"
+            guard_enabled = True
+
         buttons = [
             [InlineKeyboardButton("✏️ Interactive Edit (Tidal NG)", callback_data="tidalNgInteractive")],
+            [InlineKeyboardButton(guard_label, callback_data="tidalNgTogglePresetGuard")],
             [
                 InlineKeyboardButton("🔑 Login", callback_data="tidalNgLogin"),
                 InlineKeyboardButton("🚨 Logout", callback_data="tidalNgLogout")
@@ -1089,50 +1130,59 @@ async def tidal_ng_cb(c, cb: CallbackQuery):
                 InlineKeyboardButton("📂 Import Config File", callback_data="tidalNg_importFile"),
                 InlineKeyboardButton("⚙️ Execute cfg", callback_data="tidal_ng_execute_cfg")
             ],
-            [
-                InlineKeyboardButton("↓ Concurrency -", callback_data="tidalNgDecConcurrency"),
-                InlineKeyboardButton("↑ Concurrency +", callback_data="tidalNgIncConcurrency")
-            ],
-            [
-                InlineKeyboardButton(qa_label, callback_data="tidalNgCycleQualityAudio"),
-                InlineKeyboardButton(qv_label, callback_data="tidalNgCycleQualityVideo"),
-            ],
-            [
-                InlineKeyboardButton(vd_label, callback_data="tidalNgToggleVideoDownload"),
-                InlineKeyboardButton(xf_label, callback_data="tidalNgToggleExtractFlac"),
-            ],
-            [
-                InlineKeyboardButton(mp4_label, callback_data="tidalNgToggleConvertMp4"),
-                InlineKeyboardButton(se_label, callback_data="tidalNgToggleSkipExisting"),
-            ],
-            [
-                InlineKeyboardButton(st_label, callback_data="tidalNgToggleSymlink"),
-                InlineKeyboardButton(pc_label, callback_data="tidalNgTogglePlaylistCreate"),
-            ],
-            [
-                InlineKeyboardButton(delay_label, callback_data="tidalNgCycleDelay"),
-                InlineKeyboardButton(sim_label, callback_data="tidalNgCycleSimPerTrack"),
-            ],
-            [
-                InlineKeyboardButton(pad_label, callback_data="tidalNgCycleTrackPad"),
-                InlineKeyboardButton("Reset Delays", callback_data="tidalNgResetDelay"),
-            ],
-            [
-                InlineKeyboardButton(le_label, callback_data="tidalNgToggleLyricsEmbed"),
-                InlineKeyboardButton(lf_label, callback_data="tidalNgToggleLyricsFile"),
-            ],
-            [
-                InlineKeyboardButton(rg_label, callback_data="tidalNgToggleReplayGain"),
-                InlineKeyboardButton(ce_label, callback_data="tidalNgToggleCoverEmbed"),
-            ],
-            [
-                InlineKeyboardButton(caf_label, callback_data="tidalNgToggleCoverFile"),
-                InlineKeyboardButton(mcd_label, callback_data="tidalNgCycleCoverSize"),
-            ],
-            [
-                InlineKeyboardButton(zip_album_label, callback_data="tidalNgToggleZipAlbum"),
-                InlineKeyboardButton(zip_playlist_label, callback_data="tidalNgToggleZipPlaylist")
-            ],
+        ]
+
+        if guard_enabled:
+            buttons += [
+                [
+                    InlineKeyboardButton("↓ Concurrency -", callback_data="tidalNgDecConcurrency"),
+                    InlineKeyboardButton("↑ Concurrency +", callback_data="tidalNgIncConcurrency")
+                ],
+            ]
+        
+        if guard_enabled:
+            buttons += [
+                [
+                    InlineKeyboardButton(qa_label, callback_data="tidalNgCycleQualityAudio"),
+                    InlineKeyboardButton(qv_label, callback_data="tidalNgCycleQualityVideo"),
+                ],
+                [
+                    InlineKeyboardButton(vd_label, callback_data="tidalNgToggleVideoDownload"),
+                    InlineKeyboardButton(xf_label, callback_data="tidalNgToggleExtractFlac"),
+                ],
+                [
+                    InlineKeyboardButton(mp4_label, callback_data="tidalNgToggleConvertMp4"),
+                    InlineKeyboardButton(se_label, callback_data="tidalNgToggleSkipExisting"),
+                ],
+                [
+                    InlineKeyboardButton(st_label, callback_data="tidalNgToggleSymlink"),
+                    InlineKeyboardButton(pc_label, callback_data="tidalNgTogglePlaylistCreate"),
+                ],
+                [
+                    InlineKeyboardButton(delay_label, callback_data="tidalNgCycleDelay"),
+                    InlineKeyboardButton(sim_label, callback_data="tidalNgCycleSimPerTrack"),
+                ],
+                [
+                    InlineKeyboardButton(pad_label, callback_data="tidalNgCycleTrackPad"),
+                    InlineKeyboardButton("Reset Delays", callback_data="tidalNgResetDelay"),
+                ],
+                [
+                    InlineKeyboardButton(le_label, callback_data="tidalNgToggleLyricsEmbed"),
+                    InlineKeyboardButton(lf_label, callback_data="tidalNgToggleLyricsFile"),
+                ],
+                [
+                    InlineKeyboardButton(rg_label, callback_data="tidalNgToggleReplayGain"),
+                    InlineKeyboardButton(ce_label, callback_data="tidalNgToggleCoverEmbed"),
+                ],
+                [
+                    InlineKeyboardButton(caf_label, callback_data="tidalNgToggleCoverFile"),
+                    InlineKeyboardButton(mcd_label, callback_data="tidalNgCycleCoverSize"),
+                ],
+                [
+                    InlineKeyboardButton(zip_album_label, callback_data="tidalNgToggleZipAlbum"),
+                    InlineKeyboardButton(zip_playlist_label, callback_data="tidalNgToggleZipPlaylist")
+                ],
+            ]
             [InlineKeyboardButton("🔙 Back", callback_data="providerPanel")]
         ]
         await edit_message(
@@ -1406,6 +1456,17 @@ async def tidal_ng_toggle_zip_playlist(c, cb: CallbackQuery):
     except Exception:
         pass
     await tidal_ng_cb(c, cb)
+@Client.on_callback_query(filters.regex(pattern=r"^tidalNgTogglePresetGuard$"))
+async def tidal_ng_toggle_preset_guard(c, cb: CallbackQuery):
+    if await check_user(cb.from_user.id, restricted=True):
+        try:
+            from ..settings import bot_set
+            from ..helpers.database.pg_impl import set_db
+            bot_set.tidal_ng_cycle_presets_enabled = not bool(getattr(bot_set, 'tidal_ng_cycle_presets_enabled', True))
+            set_db.set_variable('TIDAL_NG_CYCLE_PRESETS_ENABLED', bot_set.tidal_ng_cycle_presets_enabled)
+        except Exception:
+            pass
+        await tidal_ng_cb(c, cb)
 
 
 @Client.on_callback_query(filters.regex(pattern=r"^tidalNgIncConcurrency$"))

--- a/bot/settings.py
+++ b/bot/settings.py
@@ -144,6 +144,12 @@ class BotSettings:
         # Apple flags popup for /download (Apple-only)
         self.apple_flags_popup = _to_bool(__getvalue__('APPLE_FLAGS_POPUP'))
 
+        # Preset cycling/toggle guards for panels
+        acpe, _ = set_db.get_variable('APPLE_CYCLE_PRESETS_ENABLED')
+        self.apple_cycle_presets_enabled = True if acpe is None else _to_bool(acpe)
+        tncpe, _ = set_db.get_variable('TIDAL_NG_CYCLE_PRESETS_ENABLED')
+        self.tidal_ng_cycle_presets_enabled = True if tncpe is None else _to_bool(tncpe)
+
         self.clients = []
         self.download_history = download_history
 


### PR DESCRIPTION
…NG\n\n- Top-level toggle in each panel to enable/disable cycling preset buttons\n- Prevents accidental configuration changes; interactive editors remain available