### PR TITLE
Fixing code bugs

### DIFF
--- a/bot/helpers/buttons/settings.py
+++ b/bot/helpers/buttons/settings.py
@@ -101,7 +101,7 @@ def core_buttons():
             [
                 InlineKeyboardButton(
                     text=f"Return Link : {bot_set.link_options}",
-                    callback_data='linkOptions'
+                    callback_data='linkOption'
                 )
             ]
         )

--- a/bot/modules/provider_settings.py
+++ b/bot/modules/provider_settings.py
@@ -141,13 +141,14 @@ async def apple_quality_cb(c, cb: CallbackQuery):
             'atmos': ['2768', '3072', '3456']
         }
         current_format = Config.APPLE_DEFAULT_FORMAT
-        current_quality = getattr(Config, f'APPLE_{current_format.upper()}_QUALITY')
+        # Normalize to string for comparison against button values
+        current_quality = str(getattr(Config, f'APPLE_{current_format.upper()}_QUALITY'))
         
         # Create quality buttons
         buttons = []
         for quality in qualities[current_format]:
             label = f"{quality} kbps"
-            if quality == current_quality:
+            if str(quality) == current_quality:
                 label += " ✅"
             buttons.append([InlineKeyboardButton(label, callback_data=f"appleSQ_{current_format}_{quality}")])
         
@@ -165,9 +166,13 @@ async def apple_quality_cb(c, cb: CallbackQuery):
 async def apple_set_quality_cb(c, cb: CallbackQuery):
     if await check_user(cb.from_user.id, restricted=True):
         _, format_type, quality = cb.data.split('_')
-        # Update configuration
-        set_db.set_variable(f'APPLE_{format_type.upper()}_QUALITY', quality)
-        setattr(Config, f'APPLE_{format_type.upper()}_QUALITY', quality)
+        # Update configuration (store as int for consistency)
+        try:
+            quality_val = int(quality)
+        except Exception:
+            quality_val = int(str(quality).strip())
+        set_db.set_variable(f'APPLE_{format_type.upper()}_QUALITY', quality_val)
+        setattr(Config, f'APPLE_{format_type.upper()}_QUALITY', quality_val)
         await apple_quality_cb(c, cb)
 
 

--- a/bot/modules/settings.py
+++ b/bot/modules/settings.py
@@ -110,6 +110,21 @@ async def rclone_list_remotes_cb(client, cb:CallbackQuery):
         except Exception as e:
             await edit_message(cb.message, f"Error: {e}", markup=rclone_buttons())
 
+@Client.on_callback_query(filters.regex(pattern=r"^rcloneScope$"))
+async def rclone_scope_cb(client, cb:CallbackQuery):
+    if await check_user(cb.from_user.id, restricted=True):
+        try:
+            current = (getattr(bot_set, 'rclone_copy_scope', 'FILE') or 'FILE').upper()
+            new_val = 'FOLDER' if current == 'FILE' else 'FILE'
+            bot_set.rclone_copy_scope = new_val
+            set_db.set_variable('RCLONE_COPY_SCOPE', new_val)
+        except Exception:
+            pass
+        try:
+            await rclone_panel_cb(client, cb)
+        except Exception:
+            pass
+
 @Client.on_callback_query(filters.regex(pattern=r"^rcloneSend"))
 async def rclone_send_cb(client, cb:CallbackQuery):
     if await check_user(cb.from_user.id, restricted=True):
@@ -118,7 +133,7 @@ async def rclone_send_cb(client, cb:CallbackQuery):
             return await edit_message(cb.message, "rclone.conf not found.", markup=rclone_buttons())
         # Send the file as document
         try:
-            await send_message(cb, './rclone.conf', 'doc')
+            await send_message(cb.message, './rclone.conf', 'doc')
         except Exception:
             await edit_message(cb.message, "❌ Failed to send rclone.conf", markup=rclone_buttons())
 


### PR DESCRIPTION
Fix settings UI callback mismatch, add `rcloneScope` toggle handler, correct `rcloneSend` message target, and normalize Apple quality comparisons and storage to integers.

---
<a href="https://cursor.com/background-agent?bcId=bc-994e5473-f422-4221-ab7e-3c697a3ee6bd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-994e5473-f422-4221-ab7e-3c697a3ee6bd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

